### PR TITLE
Add health endpoints

### DIFF
--- a/api/health.py
+++ b/api/health.py
@@ -1,0 +1,35 @@
+from django.db import connection
+from django.core.cache import cache
+from ninja import Router
+
+router = Router()
+
+@router.get("/live", auth=None)
+def live(request):
+    return {"status": "ok"}
+
+@router.get("/ready", auth=None)
+def ready(request):
+    checks = {}
+    ok = True
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+        checks["db"] = {"ok": True}
+    except Exception as exc:
+        checks["db"] = {"ok": False, "reason": str(exc)}
+        ok = False
+
+    try:
+        cache.set("healthcheck", "1", 5)
+        checks["cache"] = {"ok": cache.get("healthcheck") == "1"}
+        if not checks["cache"]["ok"]:
+            ok = False
+    except Exception as exc:
+        checks["cache"] = {"ok": False, "reason": str(exc)}
+        ok = False
+
+    status = "pass" if ok else "fail"
+    return (200 if ok else 503, {"status": status, "checks": checks})

--- a/config/urls.py
+++ b/config/urls.py
@@ -2,6 +2,7 @@ from django.contrib import admin
 from django.urls import path, include
 from ninja import NinjaAPI
 from api.views import router as api_router
+from api.health import router as health_router
 from rest_framework_simplejwt.views import (TokenObtainPairView, TokenRefreshView)
 
 
@@ -11,6 +12,7 @@ from rest_framework_simplejwt.views import (TokenObtainPairView, TokenRefreshVie
 # credentials.
 api = NinjaAPI()
 api.add_router("/v1/", api_router)
+api.add_router("", health_router)
 
 
 urlpatterns = [

--- a/events/tests/test_health_endpoints.py
+++ b/events/tests/test_health_endpoints.py
@@ -1,0 +1,19 @@
+from rest_framework.test import APIClient
+from django.test import TestCase
+
+
+class HealthEndpointsTests(TestCase):
+    def test_live_endpoint(self):
+        client = APIClient()
+        resp = client.get('/api/live')
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+    def test_ready_endpoint(self):
+        client = APIClient()
+        resp = client.get('/api/ready')
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "pass"
+        assert "db" in data["checks"]
+        assert "cache" in data["checks"]


### PR DESCRIPTION
## Summary
- expose `/api/live` liveness endpoint
- add `/api/ready` readiness check verifying database and cache
- cover new endpoints with tests

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68a5cfde03b08333ac1818022d681d4f